### PR TITLE
Add a webpack task that runs eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,45 @@
+{
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
+  "parser": "babel-eslint",
+  "plugins": [
+    "react"
+  ],
+  "settings": {
+    "react": {
+      "pragma": "React",  // Pragma to use, default to "React"
+      "version": "14.0" // React version, default to the latest React stable release
+    }
+  },
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "rules": {
+    "strict": [1, "safe"],
+    "quotes": [2, "single"],
+    "semi": [2, "always"],
+    "eqeqeq": [2, "smart"],
+    "no-redeclare": [2],
+    "no-unreachable": [2],
+    "no-irregular-whitespace": [2],
+    "yoda": [2, "never"],
+    "no-duplicate-case": [2],
+    "no-empty": [2],
+    "no-invalid-regexp": [2],
+    "use-isnan": [2],
+    "no-unexpected-multiline": [2],
+    "computed-property-spacing": [2, "never"],
+    "array-bracket-spacing": [2, "never"],
+    "object-curly-spacing": [1, "always"],
+    "no-extra-parens": [2, "functions"],
+    "indent": [1, 2],
+    "linebreak-style": [2, "unix"],
+    "comma-dangle": [2, "never"],
+    "no-unused-vars": [2, {"vars": "all", "varsIgnorePattern": "_"}],
+    "no-undef": [2],
+    "arrow-parens": [2, "as-needed"]
+  },
+  "globals": {
+    "require": false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "WEBPACK_TARGET=unfinished webpack-dev-server",
     "finished": "WEBPACK_TARGET=finished webpack-dev-server",
-    "build": "WEBPACK_TARGET=finished NODE_ENV=production webpack"
+    "build": "WEBPACK_TARGET=finished NODE_ENV=production webpack",
+    "start-lint": "WEBPACK_TARGET=unfinished LINT=true webpack-dev-server"
   },
   "repository": {
     "type": "git",
@@ -27,15 +28,21 @@
   "homepage": "https://github.com/freddyrangel/react-under-the-hood#readme",
   "devDependencies": {
     "babel-core": "^6.4.5",
+    "babel-eslint": "^6.0.3",
     "babel-loader": "^6.2.1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-1": "^6.5.0",
     "css-loader": "^0.23.1",
+    "eslint": "^2.8.0",
+    "eslint-config-standard": "^5.1.0",
+    "eslint-loader": "^1.3.0",
+    "eslint-plugin-react": "^5.0.1",
+    "eslint-plugin-standard": "^1.3.2",
     "file-loader": "^0.8.4",
     "html-webpack-plugin": "^1.6.1",
     "node-sass": "^3.4.2",
-    "react-addons-perf": "^15.0.1",
+    "react-addons-perf": "^0.14.3",
     "react-hot-loader": "^1.3.0",
     "sass-loader": "^3.1.2",
     "style-loader": "^0.12.4",
@@ -47,11 +54,6 @@
     "jquery": "^2.1.4",
     "jquery-ui": "^1.10.5",
     "react": "^15.0.1",
-    "react-addons-shallow-compare": "^15.0.1",
-    "react-dom": "^15.0.1",
-    "react-redux": "^4.4.5",
-    "react-router": "^2.2.4",
-    "redux": "^3.4.0",
-    "redux-thunk": "^2.0.1"
+    "react-dom": "^15.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,32 +28,37 @@
   "homepage": "https://github.com/freddyrangel/react-under-the-hood#readme",
   "devDependencies": {
     "babel-core": "^6.4.5",
-    "babel-eslint": "^6.0.3",
     "babel-loader": "^6.2.1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-1": "^6.5.0",
+    "babel-eslint": "^6.0.3",
     "css-loader": "^0.23.1",
-    "eslint": "^2.8.0",
-    "eslint-config-standard": "^5.1.0",
-    "eslint-loader": "^1.3.0",
-    "eslint-plugin-react": "^5.0.1",
-    "eslint-plugin-standard": "^1.3.2",
     "file-loader": "^0.8.4",
     "html-webpack-plugin": "^1.6.1",
     "node-sass": "^3.4.2",
-    "react-addons-perf": "^0.14.3",
+    "react-addons-perf": "^15.0.1",
     "react-hot-loader": "^1.3.0",
     "sass-loader": "^3.1.2",
     "style-loader": "^0.12.4",
     "webpack": "^1.12.14",
-    "webpack-dev-server": "^1.14.1"
+    "webpack-dev-server": "^1.14.1",
+    "eslint": "^2.8.0",
+    "eslint-config-standard": "^5.1.0",
+    "eslint-loader": "^1.3.0",
+    "eslint-plugin-react": "^5.0.1",
+    "eslint-plugin-standard": "^1.3.2"
   },
   "dependencies": {
     "immutable": "^3.7.6",
     "jquery": "^2.1.4",
     "jquery-ui": "^1.10.5",
     "react": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "react-addons-shallow-compare": "^15.0.1",
+    "react-dom": "^15.0.1",
+    "react-redux": "^4.4.5",
+    "react-router": "^2.2.4",
+    "redux": "^3.4.0",
+    "redux-thunk": "^2.0.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,4 +79,15 @@ if (process.env.NODE_ENV === "production") {
   productionPlugins.forEach((plugin) => config.plugins.push(plugin));
 }
 
+if (process.env.LINT) {
+  config.module.preLoaders = [
+    {
+      test: /\.jsx$/,
+      loader: 'eslint',
+      include: [__dirname],
+      exclude: [path.join(__dirname, './', 'node_modules'), path.join(__dirname, './', 'lib')]
+    }
+  ];
+}
+
 module.exports = config;


### PR DESCRIPTION
As promised during the training, here it is. It might come in handy for some people (if you're quickly typing iyou often make a lot of silly typos) and also adds `preLoaders` to webpack config - so you can talk about it during the webpack part :) I've created a new task so that it won't break the usual flow. But if somebody has eslint inside of his IDE it'll work as well. If you'll find it useful - cool. If not - I learned something new, so it's a win for me anyway.